### PR TITLE
Update Dockerfile's base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ghdl/runner:latest
+FROM ghdl/ghdl:ubuntu18-llvm-5.0
 
 MAINTAINER Mario Barbareschi <mario.barbareschi@unina.it>
 
-RUN apt-get update && \ 
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install cmake make git gtkwave
 


### PR DESCRIPTION
ghdl/ghdl provides a couple tags with different base distros.
I had no special reason to pick Ubuntu18, neither would I have any special reason for any other tag.

One point in favor to choosing Ubuntu is because it is the most mainstream distro, which may show itself as easier for other people tu customize this docker manifest.

Addresses #1 